### PR TITLE
Use in-publish to workaround broken npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">= 0.8.14"
   },
   "scripts": {
-    "prepublish": "cake build",
+    "prepublish": "not-in-install && cake build || in-install",
     "test": "mocha",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec",
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
@@ -37,6 +37,7 @@
     "front-matter": "^1.0.0",
     "fs-extra": "^0.26.2",
     "handlebars": "^4.0.3",
+    "in-publish": "^2.0.0",
     "js-yaml": "^3.4.3",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
npm has some really broken behaviour - on npm install
it runs the prepublish script. This often depends on
packages that should be installed during npm install, leading to
an ugly error for the user.

in-install is a package that works around this

see https://github.com/npm/npm/issues/3059 for discussion of this problem
